### PR TITLE
36 - Add prompt for options.folderName

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -43,12 +43,22 @@ let promptForMissingOptions = async (options) => {
 
   const questions = [];
 
+  if (!options.folderName) {
+    questions.push({
+        type: 'input',
+        name: 'folderName',
+        message: 'Please enter folder name:',
+        default: defaultFolderName
+    });
+  }
+
   const templateCollection = ['es6', 'cjs', 'ts-es6'];
 
   const answers = await inquirer.prompt(questions);
 
   return {
-      ...options
+      ...options,
+      folderName: options.folderName || answers.folderName
   }
 }
 


### PR DESCRIPTION
**This pull request makes the following changes**:
* Fixes issue code-collabo/node-mongo-cli#36

**Details**:
* Adds prompt for options.folderName

**Testing checklist**:
- [x] Run test case(s) in code-collabo/node-mongo-cli#36 to test that output is as expected.
- [x] I certify that I ran my checklist

Ping code-collabo/node-mongo-cli