### PR TITLE
49 - Customize cli on preinstall

### DIFF
--- a/bin/customize-preinstall
+++ b/bin/customize-preinstall
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require = require('esm')(module /*, options */);
+require('../src/customize/customize').customize();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,40 +1651,6 @@
       "dev": true,
       "optional": true
     },
-    "boxen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1807,12 +1773,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "caniuse-lite": {
@@ -1959,6 +1919,11 @@
           }
         }
       }
+    },
+    "clear": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clear/-/clear-0.1.0.tgz",
+      "integrity": "sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw=="
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -2969,6 +2934,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "figlet": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz",
+      "integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww=="
     },
     "figures": {
       "version": "3.2.0",
@@ -6106,6 +6076,28 @@
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
+        "boxen": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+          "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+          "dev": true,
+          "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^3.0.0",
+            "cli-boxes": "^2.2.0",
+            "string-width": "^4.1.0",
+            "term-size": "^2.1.0",
+            "type-fest": "^0.8.1",
+            "widest-line": "^3.1.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "chalk": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -6115,6 +6107,12 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "access": "public"
   },
   "scripts": {
+    "preinstall": "node bin/customize-preinstall",
     "prestart": "node -r esm src/startMessage.js",
     "start": "npm-run-all --parallel lint:watch",
     "lint": "esw src --color",
@@ -42,8 +43,10 @@
   "dependencies": {
     "arg": "^5.0.0",
     "chalk": "^4.1.0",
+    "clear": "^0.1.0",
     "esm": "^3.2.25",
     "execa": "^5.0.0",
+    "figlet": "^1.5.0",
     "inquirer": "^8.0.0",
     "listr": "^0.14.3",
     "ncp": "^2.0.0",

--- a/src/customize/customize.js
+++ b/src/customize/customize.js
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+import clear from 'clear';
+import figlet from 'figlet';
+
+export const customize = async () => {
+  clear();
+  console.log( chalk.greenBright(figlet.textSync('node-mongo', {
+    font: 'Small',
+    horizontalLayout: 'full'
+  })) );
+  console.log('Installing...');
+}


### PR DESCRIPTION
**This pull request makes the following changes**:
* Fixes issue code-collabo/node-mongo-cli#49

**Details**:
* Customize cli on preinstall

**Testing checklist**:
- [x] Run `npm install` or `npm i` command. Check that the texts 'node-mongo' and 'installing...' are displayed before install begins.
- [x] I certify that I ran my checklist

Ping code-collabo/node-mongo-cli