### PR TITLE
57 - configure --yes flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -57,6 +57,24 @@ let promptForMissingOptions = async (options) => {
     return tc === options.template
   });
 
+  const notAmongTemplates = equalToAtLeastOneTemplate === false;
+
+  if (notAmongTemplates && options.skipPrompts) {
+    console.log( chalk.cyanBright(`There are only 3 templates you can choose from: es6, cjs and ts-es6.
+    Cli does not have template: "${options.template}" in its template collection,
+    the default template: "${defaultTemplate}" will be used instead.`) );
+  }
+
+  if (options.skipPrompts) {
+    return {
+        ...options,
+        folderName: options.folderName || defaultFolderName,
+        template: defaultTemplate,
+        runInstall: false,
+        git: false
+    }
+  }
+
   if (!options.template || equalToAtLeastOneTemplate === false) {
       questions.push({
           type: 'list',


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#57

#### Details:
Configures --yes flag and -y alias.

#### Testing checklist:
- [x] Check that all test cases pass in issue code-collabo/node-mongo-cli#57
- [x] I certify that I ran my checklist

Ping code-collabo/node-mongo-cli