### PR TITLE
53 - configure install and skip Install flags

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -93,6 +93,11 @@ let promptForMissingOptions = async (options) => {
 
 export let cli = async (args) => {
   let options = parseArgumentsIntoOptions(args);
+
+  if (options.skipInstall) {
+    options.runInstall = false;
+  }
+
   options = await promptForMissingOptions(options);
 
   console.log(options);

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import ncp from 'ncp';
 import path from 'path';
 import { promisify } from 'util';
 import Listr from 'listr';
+import { projectInstall } from 'pkg-install';
 
 const access = promisify(fs.access);
 const copy = promisify(ncp);
@@ -48,6 +49,13 @@ export let createProject = async (options) => {
     {
       title: 'copy project files',
       task: () => copyTemplateFiles(options)
+    },
+    {
+        title: 'Install dependencies',
+        task: () => projectInstall({
+            cwd: options.targetDirectory
+        }),
+        skip: () => !options.runInstall ? 'Automatically install dependencies by doing nothing. Alternatively, pass --install or -i' : undefined
     }
   ]);
 


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#53

#### Details:
Configures --install (-i) and --skip-install (-s)

#### Testing checklist:
- [x] Check that all test cases pass in issue code-collabo/node-mongo-cli#53
- [x] I certify that I ran my checklist

Ping code-collabo/node-mongo-cli