### PR TITLE
57 - import execa to fix undefined error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import ncp from 'ncp';
 import path from 'path';
 import { promisify } from 'util';
+import execa from 'execa';
 import Listr from 'listr';
 import { projectInstall } from 'pkg-install';
 


### PR DESCRIPTION
This pull request is part of fixes made to code-collabo/node-mongo-cli#57 which was omitted in pull request #62 