### PR TITLE
76 - Fix wrong prompt when folderName arg is not present

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -107,7 +107,11 @@ let promptForMissingOptions = async (options) => {
           name: 'folderName',
           message: 'Enter different folder name:',
         });
-        folderNameAnswers = await inquirer.prompt(folderQuestions);
+        if (options.folderName) {
+          folderNameAnswers = await inquirer.prompt(folderQuestions);
+        } else {
+          folderNameAnswers = await inquirer.prompt([folderQuestions[1]]);
+        }
       }
     } while (equalToAtLeastOneFolder === true);
 


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#76 

**Details:**
* Adds fix wrong prompt when folderName arg is not present.
* Related to issue #71 

**Testing checklist:**
- [x] Check that the correct prompt pops up as expected in issue #76 
- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli
