### PR TITLE
77 - Fix empty folder prompt bug

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -62,6 +62,8 @@ let promptForMissingOptions = async (options) => {
     return files;
   });
 
+  rootDirContent.push('');
+
   let matchDefaultValue = rootDirContent.filter(content => {
     return content.match(defaultFolderName);
   });
@@ -101,7 +103,11 @@ let promptForMissingOptions = async (options) => {
       });
 
       if (equalToAtLeastOneFolder === true) {
-        console.log( chalk.cyanBright(`Folder name: "${folderNameAnswers.folderName}" already exists, enter a different folder name instead`) );
+        if (folderNameAnswers.folderName !== '') {
+          console.log( chalk.cyanBright(`Folder name: "${folderNameAnswers.folderName}" already exists, enter a different folder name instead`) );
+        } else {
+          console.log( chalk.cyanBright(`Folder name cannot be empty`) );
+        }
         folderQuestions.push({
           type: 'input',
           name: 'folderName',


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#77 

**Details:**
* Stops empty folder prompt from downloading template into src folder, by pushing empty string `''` into `rootDirContent` array.
* Adds console message `Folder name cannot be empty` for empty string.

**Testing checklist:**
- [x] Run case 1 and case 2 from #77 
- [x] Check that CLI responds with `Enter different folder name:` prompt when empty string is entered in previous prompt.
- [x] Check that the console message `Folder name cannot be empty` is displayed right until of the prompt. 
- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli