### PR TITLE
Fix default folder name increment

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import arg from 'arg';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
-import { folderNamePrompt } from './prompts/folder';
+import { folderNameMissingOptionPrompt } from './prompts/folder';
 import { createProject } from './main';
 
 let parseArgumentsIntoOptions = (rawArgs) => {
@@ -61,7 +61,7 @@ let skipPrompts = (options, defaultFolderName, notAmongTemplateCollection, defau
   return options;
 }
 
-let promptForMissingOptions = async (options, folderNameAnswers, defaultFolderName) => {
+let templateMissingOptionPrompt = async (options, folderNameAnswers, defaultFolderName) => {
   const defaultTemplate = 'esm';
 
   const templateQuestions = [];
@@ -128,11 +128,11 @@ export let cli = async (args) => {
     options.git = false;
   }
 
-  let [updatedOptions, folderNameAnswers, defaultFolderName] = await folderNamePrompt(options);
+  let [updatedOptions, folderNameAnswers, defaultFolderName] = await folderNameMissingOptionPrompt(options);
 
-  options = await promptForMissingOptions(updatedOptions, folderNameAnswers, defaultFolderName);
+  options = await templateMissingOptionPrompt(updatedOptions, folderNameAnswers, defaultFolderName);
 
-  console.log(options);
+  //console.log(options);
 
   try {
     await createProject(options);

--- a/src/cli.js
+++ b/src/cli.js
@@ -39,7 +39,7 @@ let parseArgumentsIntoOptions = (rawArgs) => {
   }
 }
 
-let promptForMissingOptions = async (options, folderNameAnswers) => {
+let promptForMissingOptions = async (options, folderNameAnswers, defaultFolderName) => {
   let defaultTemplate = 'esm';
 
   const templateQuestions = [];
@@ -54,17 +54,19 @@ let promptForMissingOptions = async (options, folderNameAnswers) => {
 
   if (notAmongTemplateCollection && options.skipPrompts && options.template !== undefined) {
     console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection, the default template: "${defaultTemplate}" will be used instead.`) );
+    options.template = defaultTemplate;
   }
 
   if (notAmongTemplateCollection && options.skipPrompts && options.template === undefined) {
     console.log( chalk.cyanBright(`No template specified, the default template: "${defaultTemplate}" will be used instead.`) );
+    options.template = defaultTemplate;
   }
 
   if (options.skipPrompts) {
     return {
       ...options,
       folderName: options.folderName || defaultFolderName,
-      template: defaultTemplate,
+      template: options.template,
       runInstall: false,
       git: false
     }
@@ -114,9 +116,9 @@ export let cli = async (args) => {
     options.git = false;
   }
 
-  let [updatedOptions, folderNameAnswers] = await folderNamePrompt(options);
+  let [updatedOptions, folderNameAnswers, defaultFolderName] = await folderNamePrompt(options);
 
-  options = await promptForMissingOptions(updatedOptions, folderNameAnswers);
+  options = await promptForMissingOptions(updatedOptions, folderNameAnswers, defaultFolderName);
 
   //console.log(options);
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,6 @@
 import arg from 'arg';
-import inquirer from 'inquirer';
-import chalk from 'chalk';
 import { folderNameMissingOptionPrompt } from './prompts/folder';
+import { templateMissingOptionPrompt } from './prompts/template';
 import { createProject } from './main';
 
 let parseArgumentsIntoOptions = (rawArgs) => {
@@ -37,84 +36,6 @@ let parseArgumentsIntoOptions = (rawArgs) => {
     runInstall: args['--install'] || true,
     skipInstall: args['--skip-install'] || false
   }
-}
-
-let skipPrompts = (options, defaultFolderName, notAmongTemplateCollection, defaultTemplate) => {
-  if (notAmongTemplateCollection && options.template !== undefined) {
-    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection, the default template: "${defaultTemplate}" will be used instead.`) );
-    options.template = defaultTemplate;
-  }
-
-  if (notAmongTemplateCollection && options.template === undefined) {
-    console.log( chalk.cyanBright(`--yes or -y flag detected. Generate "${defaultTemplate}" template since no template is specified.`) );
-    options.template = defaultTemplate;
-  }
-
-  options = {
-    ...options,
-    folderName: options.folderName || defaultFolderName,
-    template: options.template,
-    runInstall: false,
-    git: false
-  }
-
-  return options;
-}
-
-let templateMissingOptionPrompt = async (options, folderNameAnswers, defaultFolderName) => {
-  const defaultTemplate = 'esm';
-
-  const templateQuestions = [];
-
-  const templateCollection = [defaultTemplate, 'cjs', 'ts-esm'];
-
-  const equalToAtLeastOneTemplate = templateCollection.some(tc => {
-    return tc === options.template;
-  });
-
-  const notAmongTemplateCollection = equalToAtLeastOneTemplate === false;
-
-  if (!options.template || notAmongTemplateCollection) {
-    templateQuestions.push({
-      type: 'list',
-      name: 'template',
-      message: 'Please choose which project template to use',
-      choices: templateCollection,
-      default: defaultTemplate
-    });
-  }
-
-  let templateAnswers;
-
-  if (options.skipPrompts) {
-    options = skipPrompts(options, defaultFolderName, notAmongTemplateCollection, defaultTemplate);
-    templateQuestions.template = defaultTemplate;
-    templateAnswers = templateQuestions;
-  } 
-
-  if (notAmongTemplateCollection && options.template !== undefined && !options.skipPrompts) {
-    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection`) );
-  }
-
-  if (!options.skipPrompts) templateAnswers = await inquirer.prompt(templateQuestions);
-
-  if (notAmongTemplateCollection) {
-    options = {
-      ...options,
-      folderName: options.folderName || folderNameAnswers.folderName,
-      template: templateAnswers.template,
-      git: options.git
-    }
-  }
-
-  options = {
-    ...options,
-    folderName: options.folderName || folderNameAnswers.folderName,
-    template: options.template || templateAnswers.template,
-    git: options.git
-  }
-
-  return options;
 }
 
 export let cli = async (args) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,7 +46,7 @@ let skipPrompts = (options, defaultFolderName, notAmongTemplateCollection, defau
   }
 
   if (notAmongTemplateCollection && options.template === undefined) {
-    console.log( chalk.cyanBright(`No template specified, the default template: "${defaultTemplate}" will be used instead.`) );
+    console.log( chalk.cyanBright(`--yes or -y flag detected. Generate "${defaultTemplate}" template since no template is specified.`) );
     options.template = defaultTemplate;
   }
 
@@ -84,18 +84,22 @@ let promptForMissingOptions = async (options, folderNameAnswers, defaultFolderNa
     });
   }
 
+  let templateAnswers;
+
   if (options.skipPrompts) {
     options = skipPrompts(options, defaultFolderName, notAmongTemplateCollection, defaultTemplate);
+    templateQuestions.template = defaultTemplate;
+    templateAnswers = templateQuestions;
   } 
 
-  if (notAmongTemplateCollection && options.template !== undefined) {
+  if (notAmongTemplateCollection && options.template !== undefined && !options.skipPrompts) {
     console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection`) );
   }
 
-  const templateAnswers = await inquirer.prompt(templateQuestions);
+  if (!options.skipPrompts) templateAnswers = await inquirer.prompt(templateQuestions);
 
   if (notAmongTemplateCollection) {
-    return {
+    options = {
       ...options,
       folderName: options.folderName || folderNameAnswers.folderName,
       template: templateAnswers.template,
@@ -103,12 +107,14 @@ let promptForMissingOptions = async (options, folderNameAnswers, defaultFolderNa
     }
   }
 
-  return {
+  options = {
     ...options,
     folderName: options.folderName || folderNameAnswers.folderName,
     template: options.template || templateAnswers.template,
     git: options.git
   }
+
+  return options;
 }
 
 export let cli = async (args) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -39,38 +39,40 @@ let parseArgumentsIntoOptions = (rawArgs) => {
   }
 }
 
+let skipPrompts = (options, defaultFolderName, notAmongTemplateCollection, defaultTemplate) => {
+  if (notAmongTemplateCollection && options.template !== undefined) {
+    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection, the default template: "${defaultTemplate}" will be used instead.`) );
+    options.template = defaultTemplate;
+  }
+
+  if (notAmongTemplateCollection && options.template === undefined) {
+    console.log( chalk.cyanBright(`No template specified, the default template: "${defaultTemplate}" will be used instead.`) );
+    options.template = defaultTemplate;
+  }
+
+  options = {
+    ...options,
+    folderName: options.folderName || defaultFolderName,
+    template: options.template,
+    runInstall: false,
+    git: false
+  }
+
+  return options;
+}
+
 let promptForMissingOptions = async (options, folderNameAnswers, defaultFolderName) => {
-  let defaultTemplate = 'esm';
+  const defaultTemplate = 'esm';
 
   const templateQuestions = [];
 
   const templateCollection = [defaultTemplate, 'cjs', 'ts-esm'];
 
   const equalToAtLeastOneTemplate = templateCollection.some(tc => {
-    return tc === options.template
+    return tc === options.template;
   });
 
   const notAmongTemplateCollection = equalToAtLeastOneTemplate === false;
-
-  if (notAmongTemplateCollection && options.skipPrompts && options.template !== undefined) {
-    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection, the default template: "${defaultTemplate}" will be used instead.`) );
-    options.template = defaultTemplate;
-  }
-
-  if (notAmongTemplateCollection && options.skipPrompts && options.template === undefined) {
-    console.log( chalk.cyanBright(`No template specified, the default template: "${defaultTemplate}" will be used instead.`) );
-    options.template = defaultTemplate;
-  }
-
-  if (options.skipPrompts) {
-    return {
-      ...options,
-      folderName: options.folderName || defaultFolderName,
-      template: options.template,
-      runInstall: false,
-      git: false
-    }
-  }
 
   if (!options.template || notAmongTemplateCollection) {
     templateQuestions.push({
@@ -81,6 +83,10 @@ let promptForMissingOptions = async (options, folderNameAnswers, defaultFolderNa
       default: defaultTemplate
     });
   }
+
+  if (options.skipPrompts) {
+    options = skipPrompts(options, defaultFolderName, notAmongTemplateCollection, defaultTemplate);
+  } 
 
   if (notAmongTemplateCollection && options.template !== undefined) {
     console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection`) );
@@ -120,7 +126,7 @@ export let cli = async (args) => {
 
   options = await promptForMissingOptions(updatedOptions, folderNameAnswers, defaultFolderName);
 
-  //console.log(options);
+  console.log(options);
 
   try {
     await createProject(options);

--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,6 @@ export let createProject = async (options) => {
 
   await tasks.run();
 
-  console.log(`%s Project bootstrapped into the folder you specified => ${options.folderName} <=`, chalk.green.bold('DONE'));
+  console.log(`%s Project bootstrapped into the generated folder => ${options.folderName} <=`, chalk.green.bold('DONE'));
   return true;
 }

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -14,7 +14,7 @@ export const folderNamePrompt = async (options) => {
         default: folder
       });
     }
-  
+
     const rootDir = process.cwd();
     const rootDirContent = fs.readdirSync(rootDir, (err, files) => {
       if (err) {
@@ -31,11 +31,17 @@ export const folderNamePrompt = async (options) => {
     });
   
     let folderNameAnswers;
+
+    let incrementFolderName = () => {
+        if (matchDefaultValue.length >= 1) {
+            defaultFolderName = `${defaultFolderName}-${matchDefaultValue.length}`;
+          }
+    }
+
+    if (!options.folderName && options.skipPrompts) incrementFolderName();
   
-    if (!options.folderName) {
-      if (matchDefaultValue.length >= 1) {
-        defaultFolderName = `${defaultFolderName}-${matchDefaultValue.length}`;
-      }
+    if (!options.folderName && !options.skipPrompts) {
+      incrementFolderName();
       questionPush('Please enter folder name:', defaultFolderName);
       folderNameAnswers = await inquirer.prompt(folderQuestions);
     }
@@ -94,5 +100,5 @@ export const folderNamePrompt = async (options) => {
       options.folderName = folderNameAnswers.folderName;
     }
   
-    return [options, folderNameAnswers];
+    return [options, folderNameAnswers, defaultFolderName];
 }

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -49,7 +49,7 @@ export const folderNameMissingOptionPrompt = async (options) => {
     if (options.folderName && !options.skipPrompts) {
       try {
         fs.accessSync(`./${options.folderName}`, fs.constants.F_OK);
-          console.log( chalk.cyanBright(`Folder name: ${options.folderName} already exists, enter a different folder name instead`) );
+          console.log( chalk.cyanBright(`Folder name ${options.folderName} already exists`) );
           questionPush( 'Enter different folder name:', null);
           folderNameAnswers = await inquirer.prompt(folderQuestions);
       } catch (err) {
@@ -72,7 +72,7 @@ export const folderNameMissingOptionPrompt = async (options) => {
   
         if (equalToAtLeastOneFolder === true) {
           if (folderNameAnswers.folderName !== '') {
-            console.log( chalk.cyanBright(`Folder name: "${folderNameAnswers.folderName}" already exists, enter a different folder name instead`) );
+            console.log( chalk.cyanBright(`Folder name "${folderNameAnswers.folderName}" already exists`) );
           } else {
             console.log( chalk.cyanBright(`Folder name cannot be empty`) );
           }
@@ -98,7 +98,7 @@ export const folderNameMissingOptionPrompt = async (options) => {
     //Note: This affects only the try block of the previous if (options.folderName && !options.skipPrompts) statement
     if (options.folderName && !options.skipPrompts) {
       options.folderName = folderNameAnswers.folderName;
-    }
+    } //------------------------------------------------
     
     if (options.folderName && options.skipPrompts) {
       let matchFolderNameArg = rootDirContent.some(content => {

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -95,37 +95,19 @@ export const folderNamePrompt = async (options) => {
       }
     }
   
-    //Note: This affects only the try block of the previous if (options.folderName) statement
+    //Note: This affects only the try block of the previous if (options.folderName && !options.skipPrompts) statement
     if (options.folderName && !options.skipPrompts) {
       options.folderName = folderNameAnswers.folderName;
     }
-
+    
     if (options.folderName && options.skipPrompts) {
-
-      let matchFolderNameArg = rootDirContent.filter(content => {
-        return content.match(options.folderName);
+      let matchFolderNameArg = rootDirContent.some(content => {
+        return content === options.folderName;
       });
 
-      console.log(matchFolderNameArg)
-
       if (matchFolderNameArg) {
-        console.log(matchFolderNameArg)
         options.folderName = incrementFolderName();
       }
-
-      /*if (matchFolderNameArg) {
-        console.log(matchDefaultValue)
-        options.folderName = incrementFolderName();
-      }*/
-
-      //console.log(matchFolderNameArg);
-      /*if (matchDefaultValue) {
-        console.log(matchDefaultValue)
-      }*/
-      /*if (matchDefaultValue) {
-        options.folderName = incrementFolderName();
-      }*/
-        //options.folderName = incrementFolderName();
     }
   
     return [options, folderNameAnswers, defaultFolderName];

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -32,10 +32,18 @@ export const folderNameMissingOptionPrompt = async (options) => {
   
     let folderNameAnswers;
 
+    let extractedNumbers = matchDefaultValue.map((value) => {
+      let valueMatch = value.match(/(\d+)/);
+      if (valueMatch !== null) return value.match(/(\d+)/).map(Number)[0];
+    }).filter(value => { return value !== undefined; });
+
+    let maxNumber = Math.max(...extractedNumbers);
+
     let incrementFolderName = () => {
-        if (matchDefaultValue.length >= 1) {
-            defaultFolderName = `${defaultFolderName}-${matchDefaultValue.length}`;
-          }
+      if (matchDefaultValue.length >= 1) {
+        if (maxNumber === -Infinity) defaultFolderName = `${defaultFolderName}-${matchDefaultValue.length}`;
+          else defaultFolderName = `${defaultFolderName}-${maxNumber + 1}`;
+      }
     }
 
     if (!options.folderName && options.skipPrompts) incrementFolderName();

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -1,0 +1,98 @@
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import fs from 'fs';
+
+export const folderNamePrompt = async (options) => {
+    let defaultFolderName = 'node-mongo-kit';
+    const folderQuestions = [];
+  
+    let questionPush = (msgString, folder) => {
+      folderQuestions.push({
+        type: 'input',
+        name: 'folderName',
+        message: msgString,
+        default: folder
+      });
+    }
+  
+    const rootDir = process.cwd();
+    const rootDirContent = fs.readdirSync(rootDir, (err, files) => {
+      if (err) {
+        throw err;
+      }
+  
+      return files;
+    });
+  
+    rootDirContent.push('');
+  
+    let matchDefaultValue = rootDirContent.filter(content => {
+      return content.match(defaultFolderName);
+    });
+  
+    let folderNameAnswers;
+  
+    if (!options.folderName) {
+      if (matchDefaultValue.length >= 1) {
+        defaultFolderName = `${defaultFolderName}-${matchDefaultValue.length}`;
+      }
+      questionPush('Please enter folder name:', defaultFolderName);
+      folderNameAnswers = await inquirer.prompt(folderQuestions);
+    }
+  
+    if (options.folderName) {
+      try {
+        fs.accessSync(`./${options.folderName}`, fs.constants.F_OK);
+          console.log( chalk.cyanBright(`Folder name: ${options.folderName} already exists, enter a different folder name instead`) );
+          questionPush( 'Enter different folder name:', null);
+          folderNameAnswers = await inquirer.prompt(folderQuestions);
+      } catch (err) {
+        if (err) {
+          folderNameAnswers = {};
+          folderNameAnswers.folderName = options.folderName;
+         }
+      }
+    }
+  
+    try {
+      fs.accessSync(`./${folderNameAnswers.folderName}`, fs.constants.F_OK);
+  
+      let equalToAtLeastOneFolder;
+  
+      do {
+        equalToAtLeastOneFolder = rootDirContent.some(content => {
+          return content === folderNameAnswers.folderName;
+        });
+  
+        if (equalToAtLeastOneFolder === true) {
+          if (folderNameAnswers.folderName !== '') {
+            console.log( chalk.cyanBright(`Folder name: "${folderNameAnswers.folderName}" already exists, enter a different folder name instead`) );
+          } else {
+            console.log( chalk.cyanBright(`Folder name cannot be empty`) );
+          }
+          folderQuestions.push({
+            type: 'input',
+            name: 'folderName',
+            message: 'Enter different folder name:',
+          });
+          if (options.folderName) {
+            folderNameAnswers = await inquirer.prompt(folderQuestions);
+          } else {
+            folderNameAnswers = await inquirer.prompt([folderQuestions[1]]);
+          }
+        }
+      } while (equalToAtLeastOneFolder === true);
+  
+    } catch (err) {
+      if (err) {
+        //Dummy if statement to prevent: unhandledPromiseRejectionWarning in console
+      }
+    }
+  
+    //Note: This affects only the try block of the previous if (options.folderName) statement
+    if (options.folderName) {
+      options.folderName = folderNameAnswers.folderName;
+    }
+  
+    return [options, folderNameAnswers];
+}

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -2,7 +2,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import fs from 'fs';
 
-export const folderNamePrompt = async (options) => {
+export const folderNameMissingOptionPrompt = async (options) => {
     let defaultFolderName = 'node-mongo-kit';
     const folderQuestions = [];
   

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -46,7 +46,7 @@ export const folderNamePrompt = async (options) => {
       folderNameAnswers = await inquirer.prompt(folderQuestions);
     }
   
-    if (options.folderName) {
+    if (options.folderName && !options.skipPrompts) {
       try {
         fs.accessSync(`./${options.folderName}`, fs.constants.F_OK);
           console.log( chalk.cyanBright(`Folder name: ${options.folderName} already exists, enter a different folder name instead`) );
@@ -96,8 +96,12 @@ export const folderNamePrompt = async (options) => {
     }
   
     //Note: This affects only the try block of the previous if (options.folderName) statement
-    if (options.folderName) {
+    if (options.folderName && !options.skipPrompts) {
       options.folderName = folderNameAnswers.folderName;
+    }
+
+    if (options.folderName && options.skipPrompts) {
+        options.folderName = incrementFolderName();
     }
   
     return [options, folderNameAnswers, defaultFolderName];

--- a/src/prompts/folder.js
+++ b/src/prompts/folder.js
@@ -101,7 +101,31 @@ export const folderNamePrompt = async (options) => {
     }
 
     if (options.folderName && options.skipPrompts) {
+
+      let matchFolderNameArg = rootDirContent.filter(content => {
+        return content.match(options.folderName);
+      });
+
+      console.log(matchFolderNameArg)
+
+      if (matchFolderNameArg) {
+        console.log(matchFolderNameArg)
         options.folderName = incrementFolderName();
+      }
+
+      /*if (matchFolderNameArg) {
+        console.log(matchDefaultValue)
+        options.folderName = incrementFolderName();
+      }*/
+
+      //console.log(matchFolderNameArg);
+      /*if (matchDefaultValue) {
+        console.log(matchDefaultValue)
+      }*/
+      /*if (matchDefaultValue) {
+        options.folderName = incrementFolderName();
+      }*/
+        //options.folderName = incrementFolderName();
     }
   
     return [options, folderNameAnswers, defaultFolderName];

--- a/src/prompts/template.js
+++ b/src/prompts/template.js
@@ -1,0 +1,78 @@
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+
+let skipPromptsModified = (options, defaultFolderName, notAmongTemplateCollection, defaultTemplate) => {
+  if (notAmongTemplateCollection && options.template !== undefined) {
+    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection, the default template: "${defaultTemplate}" will be used instead.`) );
+    options.template = defaultTemplate;
+  }
+
+  if (notAmongTemplateCollection && options.template === undefined) {
+    console.log( chalk.cyanBright(`--yes or -y flag detected. Generate "${defaultTemplate}" template since no template is specified.`) );
+    options.template = defaultTemplate;
+  }
+
+  options = {
+    ...options,
+    folderName: options.folderName || defaultFolderName,
+    template: options.template,
+    runInstall: false,
+    git: false
+  }
+
+  return options;
+}
+
+export const templateMissingOptionPrompt = async (options, folderNameAnswers, defaultFolderName) => {
+  const defaultTemplate = 'esm';
+  const templateQuestions = [];
+  const templateCollection = [defaultTemplate, 'cjs', 'ts-esm'];
+
+  const equalToAtLeastOneTemplate = templateCollection.some(tc => {
+    return tc === options.template;
+  });
+
+  const notAmongTemplateCollection = equalToAtLeastOneTemplate === false;
+
+  if (!options.template || notAmongTemplateCollection) {
+    templateQuestions.push({
+      type: 'list',
+      name: 'template',
+      message: 'Please choose which project template to use',
+      choices: templateCollection,
+      default: defaultTemplate
+    });
+  }
+
+  let templateAnswers;
+
+  if (options.skipPrompts) {
+    options = skipPromptsModified(options, defaultFolderName, notAmongTemplateCollection, defaultTemplate);
+    templateQuestions.template = defaultTemplate;
+    templateAnswers = templateQuestions;
+  } 
+
+  if (notAmongTemplateCollection && options.template !== undefined && !options.skipPrompts) {
+    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection`) );
+  }
+
+  if (!options.skipPrompts) templateAnswers = await inquirer.prompt(templateQuestions);
+
+  if (notAmongTemplateCollection) {
+    options = {
+      ...options,
+      folderName: options.folderName || folderNameAnswers.folderName,
+      template: templateAnswers.template,
+      git: options.git
+    }
+  }
+
+  options = {
+    ...options,
+    folderName: options.folderName || folderNameAnswers.folderName,
+    template: options.template || templateAnswers.template,
+    git: options.git
+  }
+
+  return options;
+}

--- a/src/prompts/template.js
+++ b/src/prompts/template.js
@@ -1,14 +1,7 @@
 import inquirer from 'inquirer';
-import chalk from 'chalk';
 
 let skipPromptsModified = (options, defaultFolderName, notAmongTemplateCollection, defaultTemplate) => {
-  if (notAmongTemplateCollection && options.template !== undefined) {
-    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection, the default template: "${defaultTemplate}" will be used instead.`) );
-    options.template = defaultTemplate;
-  }
-
-  if (notAmongTemplateCollection && options.template === undefined) {
-    console.log( chalk.cyanBright(`--yes or -y flag detected. Generate "${defaultTemplate}" template since no template is specified.`) );
+  if (notAmongTemplateCollection && (options.template !== undefined || options.template === undefined)) {
     options.template = defaultTemplate;
   }
 
@@ -50,10 +43,6 @@ export const templateMissingOptionPrompt = async (options, folderNameAnswers, de
     options = skipPromptsModified(options, defaultFolderName, notAmongTemplateCollection, defaultTemplate);
     templateQuestions.template = defaultTemplate;
     templateAnswers = templateQuestions;
-  } 
-
-  if (notAmongTemplateCollection && options.template !== undefined && !options.skipPrompts) {
-    console.log( chalk.cyanBright(`Cli does not have template: "${options.template}" in its template collection`) );
   }
 
   if (!options.skipPrompts) templateAnswers = await inquirer.prompt(templateQuestions);


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#87 

**Details:**
* Fixes folder increment i.e. prevents prompt when folder name matches default folder name.

**Testing checklist:**
- [x] Number attached to default folder name should continue to increase even if one or more of the folders have been deleted somewhere in the middle.
- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli
