### PR TITLE
Configure help flag to work

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,13 +1,19 @@
 import arg from 'arg';
+import { help } from './help';
 import { folderNameMissingOptionPrompt } from './prompts/foldername';
 import { templateMissingOptionPrompt } from './prompts/template';
 import { downloadTemplateKit } from './main';
 
 let parseArgumentsIntoOptions = (rawArgs) => {
 
-  //make -x the alias for --skip-git
+  //configure --skip-git flag
   let myHandler = (value, argName, previousValue) => {
     return previousValue || '--skip-git';
+  }
+
+  //configure --help flag
+  let helpHandler = (value, argName, previousValue) => {
+    return previousValue || '--help';
   }
 
   const args = arg({
@@ -21,7 +27,9 @@ let parseArgumentsIntoOptions = (rawArgs) => {
     '-x': '--skip-git',
     '-y': '--yes',
     '-i': '--install',
-    '-s': '--skip-install'
+    '-s': '--skip-install',
+    '--help': arg.flag(helpHandler),
+    '-h': '--help'
   },
   {
     argv: rawArgs.slice(2)
@@ -34,13 +42,12 @@ let parseArgumentsIntoOptions = (rawArgs) => {
     folderName: args._[0],
     template: args._[1],
     runInstall: args['--install'] || true,
-    skipInstall: args['--skip-install'] || false
+    skipInstall: args['--skip-install'] || false,
+    help: args['--help'] || false
   }
 }
 
-export let cli = async (args) => {
-  let options = parseArgumentsIntoOptions(args);
-
+let otherOptions = async (options) => {
   if (options.skipInstall) {
     options.runInstall = false;
   }
@@ -59,5 +66,15 @@ export let cli = async (args) => {
     await downloadTemplateKit(options);
   } catch (err) {
     console.log('Error | ', err);
+  }
+}
+
+export let cli = async (args) => {
+  let options = parseArgumentsIntoOptions(args);
+
+  if (options.help) {
+    help();
+  } else {
+    await otherOptions(options);
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,6 +22,7 @@ let parseArgumentsIntoOptions = (rawArgs) => {
     '--yes': Boolean,
     '--install': Boolean,
     '--skip-install': Boolean,
+    '--help': Boolean,
     '-g': '--git',
     '--skip-git': arg.flag(myHandler), //eslint-disable-line no-dupe-keys
     '-x': '--skip-git',

--- a/src/help.js
+++ b/src/help.js
@@ -1,0 +1,34 @@
+
+export const help = () => {
+console.log(
+`Usage:
+node-mongo <folder_name> <template>  
+
+Command:
+node-mongo
+
+Arguments:
+<folder_name>   Replace this with your folder name
+<template>      Available templates: esm, cjs and ts
+
+Usage example:
+node-mongo test-folder cjs
+
+The above example bootstraps the cjs template i.e. 
+the common js template into a folder named test-folder.
+
+Prompts:
+If you do not specify one or both arguments above, 
+you will be prompted to type in folder name and/or 
+choose template option from list.
+
+Flags:
+-h, --help          Show help
+-i, --install       Install dependencies
+-g, --git           Initialize git repo
+-s, --skip-install  Skip installing dependencies
+-x, --skip-git      Skip initializing git
+-y, --yes           Skip both install and git, and use esm template as default
+`
+);
+}


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#85 

**Details:**
* Configures `--help` flag and alias `-h` to return commands, examples and flags for running the project.

**Testing checklist:**
- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli
