### PR TITLE
Configure --version flag to show cli's version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ node-mongo test-folder cjs
 ### Flags
 ````
 -h, --help          Show help
+-v, --version       Show version number
 -i, --install       Install dependencies
 -g, --git           Initialize git repo
 -s, --skip-install  Skip installing dependencies

--- a/doc/README.md
+++ b/doc/README.md
@@ -60,6 +60,7 @@ node-mongo test-folder cjs
 
 ```text
 -h, --help          Show help
+-v, --version       Show version number
 -i, --install       Install dependencies
 -g, --git           Initialize git repo
 -s, --skip-install  Skip installing dependencies

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 import arg from 'arg';
 import { help } from './help';
+import { version } from './version';
 import { notRecognised } from './help';
 import { folderNameMissingOptionPrompt } from './prompts/foldername';
 import { templateMissingOptionPrompt } from './prompts/template';
@@ -17,6 +18,11 @@ let parseArgumentsIntoOptions = (rawArgs) => {
     return previousValue || '--help';
   }
 
+  //configure --version flag
+  let versionHelper = (value, argName, previousValue) => {
+    return previousValue || '--version';
+  }
+
   try {
     const args = arg({
       '--git': Boolean,
@@ -32,7 +38,9 @@ let parseArgumentsIntoOptions = (rawArgs) => {
       '-i': '--install',
       '-s': '--skip-install',
       '--help': arg.flag(helpHandler),
-      '-h': '--help'
+      '-h': '--help',
+      '--version': arg.flag(versionHelper),
+      '-v': '--version'
     },
     {
       argv: rawArgs.slice(2)
@@ -46,7 +54,8 @@ let parseArgumentsIntoOptions = (rawArgs) => {
       template: args._[1],
       runInstall: args['--install'] || true,
       skipInstall: args['--skip-install'] || false,
-      help: args['--help'] || false
+      help: args['--help'] || false,
+      version: args['--version'] || false
     }  
   } catch (err) {
     notRecognised();
@@ -81,6 +90,8 @@ export let cli = async (args) => {
   try {
     if (options.help) {
       help();
+    } else if (options.version) {
+      version();
     } else {
       await otherOptions(options);
     }

--- a/src/help.js
+++ b/src/help.js
@@ -27,6 +27,7 @@ the prompt or type in your preferred folder name.
 
 Flags:
 -h, --help          Show help
+-v, --version       Show version number
 -i, --install       Install dependencies
 -g, --git           Initialize git repo
 -s, --skip-install  Skip installing dependencies

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,9 @@
+import package_json from '../package.json';
+
+export const version = () => {
+console.log(
+`
+node-mongo-cli v${package_json.version}
+`
+);
+}


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#136

**Details/Testing checklist:**
- [x] Configure --version flag and -v alias to show cli's version number
- [x] Update help info, readme and (gitbook) doc with --version flag
- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli
