### PR TITLE
Fix: Help CLI user know where to report errors and that manual download options for API templates exist if they encounter error while using the CLI

### DIFF
--- a/templates/cjs/src/server.js
+++ b/templates/cjs/src/server.js
@@ -12,5 +12,7 @@ server.listen(port, () => {
     console.log( chalk.cyanBright(`\nServer running at http://localhost:${port}`) );
   }catch(err) {
     console.log(err);
+    console.log(chalk.redBright(`\nYou can report the error you encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md\n`));
+    console.log(chalk.redBright(`\nThere is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates\n`))
   }
 });

--- a/templates/esm/src/server.js
+++ b/templates/esm/src/server.js
@@ -12,5 +12,7 @@ server.listen(port, () => {
     console.log( chalk.cyanBright(`\nServer running at http://localhost:${port}`) );
   }catch(err) {
     console.log(err);
+    console.log(chalk.redBright(`\nYou can report the error you encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md\n`));
+    console.log(chalk.redBright(`\nThere is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates\n`))
   }
 });


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fix https://github.com/code-collabo/node-mongo/issues/32

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

- [x]  Where they can report the error is included in the error message displayed to the user
- [x]  Where they can find the manual download option for the API boilerplate template is included in the error message displayed 
    to the user
- [x]  I certify that I ran my checklist

Ping @code-collabo/node-mongo-cli
