### PR TITLE
Fix: Generate/create ISC license files for the template that the CLI generates for users

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,12 +81,10 @@ export let downloadTemplateKit = async (options) => {
       new URL(currentFileUrl).pathname.indexOf("/") + 1
     );
 
-
   const templateDir = path.resolve(newUrl, '../../templates', options.template.toLowerCase());
 
   options.templateDirectory = templateDir;
 
-  
   try {
     await access(templateDir, fs.constants.R_OK).then(_ => {
       /* rename name option in package.json same as project/folder name */

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,12 @@ let createEnvFiles = async (options) => {
   return;
 }
 
+let createLisenceFiles = async (options) => {
+  const content = 'ISC License (ISC) Copyright 2022 Mary Obiagba Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.'
+   fs.writeFileSync(path.join(options.targetDirectory, 'LICENSE'), content);
+   return;
+}
+
 let copyTemplateFolderContent = async (options) => {
   return copy(options.templateDirectory, options.targetDirectory, {
     clobber: false
@@ -76,7 +82,7 @@ export let downloadTemplateKit = async (options) => {
     );
 
   const templateDir = path.resolve(newUrl, '../../templates', options.template.toLowerCase());
-  
+
   options.templateDirectory = templateDir;
 
   try {
@@ -86,7 +92,7 @@ export let downloadTemplateKit = async (options) => {
         cwd: options.targetDirectory
       }).stdout.pipe(process.stdout);
     })
-    
+
   }catch (err) {
     console.error(`\n%s Template name or directory path is (probably) incorrect`, chalk.red.bold('ERROR'));
     process.exit(1);
@@ -95,6 +101,8 @@ export let downloadTemplateKit = async (options) => {
   await createGitIgnoreFile(options);
 
   await createEnvFiles(options);
+
+  await createLisenceFiles(options);
 
   const listrTasks = new Listr([
     {

--- a/src/main.js
+++ b/src/main.js
@@ -81,10 +81,12 @@ export let downloadTemplateKit = async (options) => {
       new URL(currentFileUrl).pathname.indexOf("/") + 1
     );
 
+
   const templateDir = path.resolve(newUrl, '../../templates', options.template.toLowerCase());
 
   options.templateDirectory = templateDir;
 
+  
   try {
     await access(templateDir, fs.constants.R_OK).then(_ => {
       /* rename name option in package.json same as project/folder name */


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fix https://github.com/code-collabo/node-mongo/issues/33

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

- [x] The CLI now generates ISC license for the 3 API templates it generates
- [x]  The ISC license file content added is correct
- [x]  I certify that I ran my checklist

Ping @code-collabo/node-mongo-cli
