### PR TITLE
Fix: The .env/.env.example files generated by the CLI still use old content

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ let createGitIgnoreFile = async (options) => {
 }
 
 let createEnvFiles = async (options) => {
-  const content = 'MONGODB_URI=\nMONGODB_ATLAS_URI=';
+  const content = 'PORT=8080 MONGODB_LOCAL_URI= MONGODB_ATLAS_URI= CLIENT_APP_PORT= CLIENT_APP_URL=';
   fs.writeFileSync(path.join(options.targetDirectory, '.env'), content);
   fs.writeFileSync(path.join(options.targetDirectory, '.env.example'), content);
   return;
@@ -76,7 +76,7 @@ export let downloadTemplateKit = async (options) => {
     );
 
   const templateDir = path.resolve(newUrl, '../../templates', options.template.toLowerCase());
-  
+
   options.templateDirectory = templateDir;
 
   try {
@@ -86,7 +86,7 @@ export let downloadTemplateKit = async (options) => {
         cwd: options.targetDirectory
       }).stdout.pipe(process.stdout);
     })
-    
+
   }catch (err) {
     console.error(`\n%s Template name or directory path is (probably) incorrect`, chalk.red.bold('ERROR'));
     process.exit(1);

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ let createGitIgnoreFile = async (options) => {
 }
 
 let createEnvFiles = async (options) => {
-  const content = 'PORT=8080 MONGODB_LOCAL_URI= MONGODB_ATLAS_URI= CLIENT_APP_PORT= CLIENT_APP_URL=';
+  const content = 'PORT=8080\nMONGODB_URI=\nMONGODB_ATLAS_URI= \n\nCLIENT_APP_PORT\nCLIENT_APP_URL';
   fs.writeFileSync(path.join(options.targetDirectory, '.env'), content);
   fs.writeFileSync(path.join(options.targetDirectory, '.env.example'), content);
   return;

--- a/src/main.js
+++ b/src/main.js
@@ -74,10 +74,9 @@ export let downloadTemplateKit = async (options) => {
     newUrl = new URL(currentFileUrl).pathname.substring(
       new URL(currentFileUrl).pathname.indexOf("/") + 1
     );
-
   const templateDir = path.resolve(newUrl, '../../templates', options.template.toLowerCase());
 
-  options.templateDirectory = templateDir;
+   options.templateDirectory = templateDir;
 
   try {
     await access(templateDir, fs.constants.R_OK).then(_ => {
@@ -86,7 +85,7 @@ export let downloadTemplateKit = async (options) => {
         cwd: options.targetDirectory
       }).stdout.pipe(process.stdout);
     })
-
+    
   }catch (err) {
     console.error(`\n%s Template name or directory path is (probably) incorrect`, chalk.red.bold('ERROR'));
     process.exit(1);

--- a/src/main.js
+++ b/src/main.js
@@ -74,9 +74,10 @@ export let downloadTemplateKit = async (options) => {
     newUrl = new URL(currentFileUrl).pathname.substring(
       new URL(currentFileUrl).pathname.indexOf("/") + 1
     );
+
   const templateDir = path.resolve(newUrl, '../../templates', options.template.toLowerCase());
 
-   options.templateDirectory = templateDir;
+  options.templateDirectory = templateDir;
 
   try {
     await access(templateDir, fs.constants.R_OK).then(_ => {
@@ -85,7 +86,7 @@ export let downloadTemplateKit = async (options) => {
         cwd: options.targetDirectory
       }).stdout.pipe(process.stdout);
     })
-    
+
   }catch (err) {
     console.error(`\n%s Template name or directory path is (probably) incorrect`, chalk.red.bold('ERROR'));
     process.exit(1);


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes https://github.com/code-collabo/node-mongo/issues/34

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

- [x] The content of the.env files generated by the CLI is the same as the one found in the API repo
- [x]  I certify that I ran my checklist

Ping @code-collabo/node-mongo-cli
