### PR TITLE
FIX: Make CLI generate ts template too

### DIFF
--- a/src/prompts/template.js
+++ b/src/prompts/template.js
@@ -20,7 +20,7 @@ let skipPromptsModified = (options, defaultFolderName, notAmongTemplateCollectio
 export const templateMissingOptionPrompt = async (options, folderNameAnswers, defaultFolderName) => {
   const defaultTemplate = 'esm';
   const templateQuestions = [];
-  const templateCollection = [defaultTemplate, 'cjs'];
+  const templateCollection = [defaultTemplate, 'cjs', 'ts'];
 
   const equalToAtLeastOneTemplate = templateCollection.some(tc => {
     return tc === options.template;

--- a/templates/ts/dummy_file.txt
+++ b/templates/ts/dummy_file.txt
@@ -1,0 +1,25 @@
+# Contributor's individual project development guide for node-mongo-cli
+
+-------------------------------------------------------------------------------
+
+# clone the node-mongo-cli repo (you should fork it first)
+# go to the root folder of the node-mongo cli repo downloaded
+
+# install dependencies using:
+npm install
+
+-------------------------------------------------------------------------------
+
+# add to global packages using the command below:
+'npm link' or 'npm install -g i .'
+
+# to confirm if the node-mongo-cli package is installed globally use:
+npm list -g
+
+-------------------------------------------------------------------------------
+
+# when done with development and you want to remove the package globally, use:
+npm uninstall -g @code-collabo/node-mongo-cli
+
+# you can confirm if the package is removed using:
+npm list -g

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "node-mongo-api-boilerplate-template-ts",
+  "version": "1.0.0",
+  "description": "@code-collabo node-mongo API boilerplate template - typescript",
+  "main": "src/server.[atlas/local].ts",
+  "scripts": {
+    "dev:local": "ts-node-dev --respawn --transpile-only src/server.local.ts",
+    "dev:atlas": "ts-node-dev --respawn --transpile-only src/server.atlas.ts",
+    "lint": "esw src --ext .ts --color",
+    "lint:watch": "npm run lint -- --watch"
+  },
+  "author": "Obiagba Mary",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.0",
+    "express": "^4.17.3",
+    "mongoose": "^6.2.4",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "@types/body-parser": "^1.19.2",
+    "@types/chalk": "^2.2.0",
+    "@types/cors": "^2.8.12",
+    "@types/express": "^4.17.13",
+    "@types/morgan": "^1.9.3",
+    "@types/node": "^17.0.21",
+    "@typescript-eslint/eslint-plugin": "^5.59.0",
+    "@typescript-eslint/parser": "^5.59.0",
+    "chalk": "^5.0.0",
+    "eslint": "^8.39.0",
+    "eslint-watch": "^8.0.0",
+    "ts-node-dev": "^1.1.8",
+    "typescript": "^4.6.2"
+  }
+}


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes code-collabo/node-mongo#29

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**
- [x] (Dummy) ts template has been added to the CLI for testing
- [x] The CLI is able to generate the ts template
- [x] No CLI feature was broken while adding this enhancement
- [x] I certify that I ran my checklist

Ping @code-collabo/node-mongo-cli
