### PR TITLE
Fix: Help CLI user know where to report errors and that manual download options for API templates exist if they encounter error while using the CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -98,6 +98,7 @@ export let cli = async (args) => {
       await otherOptions(options);
     }
   } catch (err) {
+    console.log('');
     console.log(' You can report the error you encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md');
     console.log(' There is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates');
   } 

--- a/src/cli.js
+++ b/src/cli.js
@@ -81,6 +81,8 @@ let otherOptions = async (options) => {
     await downloadTemplateKit(options);
   } catch (err) {
     console.log('Error | ', err);
+    console.log('That they can report the error they encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md');
+    console.log('That there is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates');
   }
 }
 
@@ -96,6 +98,7 @@ export let cli = async (args) => {
       await otherOptions(options);
     }
   } catch (err) {
-    console.log('');
+    console.log(' You can report the error you encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md');
+    console.log(' There is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates');
   } 
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -81,8 +81,8 @@ let otherOptions = async (options) => {
     await downloadTemplateKit(options);
   } catch (err) {
     console.log('Error | ', err);
-    console.log('That they can report the error they encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md');
-    console.log('That there is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates');
+    console.log('You can report the error they encountered at https://github.com/code-collabo/node-mongo-cli/issues/new?assignees=&labels=bug&template=cli-user-error-report.md');
+    console.log('There is a manual download option for the API boilerplate templates at: https://github.com/code-collabo/node-mongo-api-boilerplate-templates');
   }
 }
 


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fix https://github.com/code-collabo/node-mongo/issues/32

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

- [x]  Where they can report the error is included in the error message displayed to the user
- [x]  Where they can find the manual download option for the API boilerplate template is included in the error message displayed to the user
- [x]  I certify that I ran my checklist

Ping @code-collabo/node-mongo-cli
