### PR TITLE
Fix : Write js script to remove automatically generated folders in the node-mongo CLI during development #42

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+const foldersToDelete = ["src/app", "src/app/styles"];
+
+function deleteFolder(folderPath) {
+  if (fs.existsSync(folderPath)) {
+    fs.readdirSync(folderPath).forEach((file) => {
+      const filePath = path.join(folderPath, file);
+      if (fs.lstatSync(filePath).isDirectory()) {
+        deleteFolder(filePath);
+      } else {
+        fs.unlinkSync(filePath);
+      }
+    });
+    fs.rmdirSync(folderPath);
+    console.log(`${folderPath} folder deleted successfully.`);
+  }
+}
+
+foldersToDelete.forEach((folderName) => {
+  const folderPath = path.join(__dirname, folderName);
+  deleteFolder(folderPath);
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "npm-run-all --parallel test-message dev-test",
     "dev-test": "nodemon --exec babel-node spec/run.js",
     "CI-test": "babel-node spec/run.js",
-    "test-message": "node -r esm src/customize/testMessage"
+    "test-message": "node -r esm src/customize/testMessage",
+    "cleanup": "node cleanUp.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes code-collabo/node-mongo#42

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

Replace this text with the testing checklist from the issue this pull request fixes.

Ping @code-collabo/node-mongo-cli
