### PR TITLE
Fix: API crashes when user runs dev:local script command without local files and vice versa

### DIFF
--- a/templates/cjs/package.json
+++ b/templates/cjs/package.json
@@ -5,8 +5,8 @@
   "main": "src/server.[atlas/local].js",
   "scripts": {
     "dev": "node -r esm node-mongo.js",
-    "dev:local": "nodemon --exec node src/server.local.js",
-    "dev:atlas": "nodemon --exec node src/server.atlas.js",
+    "dev:local": "if [ ! -f ./src/server.local.js ]; then echo \"Error: You can only run dev:local in local development mode\"; exit 1; fi && nodemon --exec node src/server.local.js",
+    "dev:atlas": "if [ ! -f ./src/server.atlas.js ]; then echo \"Error: You can only run dev:atlas in Atlas mode\"; exit 1; fi && nodemon --exec node src/server.atlas.js",
     "lint": "esw src --color",
     "lint:watch": "npm run lint -- --watch",
     "dev:restore": "node -r esm node-mongo.js",

--- a/templates/esm/package.json
+++ b/templates/esm/package.json
@@ -5,8 +5,8 @@
   "main": "src/server.[atlas/local].js",
   "scripts": {
     "dev": "node -r esm node-mongo.js",
-    "dev:local": "nodemon --exec babel-node src/server.local.js",
-    "dev:atlas": "nodemon --exec babel-node src/server.atlas.js",
+    "dev:local": "if [ ! -f ./src/server.local.js ]; then echo \"Error: You can only run dev:local in local development mode\"; exit 1; fi && nodemon --exec babel-node src/server.local.js",
+    "dev:atlas": "if [ ! -f ./src/server.atlas.js ]; then echo \"Error: You can only run dev:atlas in Atlas mode\"; exit 1; fi && nodemon --exec babel-node src/server.atlas.js",
     "lint": "esw src --color",
     "lint:watch": "npm run lint -- --watch",
     "dev:restore": "node -r esm node-mongo.js",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -5,8 +5,8 @@
   "main": "src/server.[atlas/local].ts",
   "scripts": {
     "dev": "node -r esm node-mongo.js",
-    "dev:local": "nodemon --exec ts-node src/server.local.ts",
-    "dev:atlas": "nodemon --exec ts-node src/server.atlas.ts",
+    "dev:local": "if [ ! -f ./src/server.local.ts ]; then echo \"Error: You can only run dev:local in local development mode\"; exit 1; fi && nodemon --exec ts-node src/server.local.ts",
+    "dev:atlas": "if [ ! -f ./src/server.atlas.ts ]; then echo \"Error: You can only run dev:atlas in Atlas mode\"; exit 1; fi && nodemon --exec ts-node src/server.atlas.ts",
     "lint": "esw src --ext .ts --color",
     "lint:watch": "npm run lint -- --watch",
     "dev:restore": "node -r esm node-mongo.js",


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes code-collabo/node-mongo#54

**General checklist**
- [x] File or folder now contains changes as specified in the issue I worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**
- [x] When user is still in atlas mode: User has been informed that they can only use or access the `dev:local` script command when they have switched to local connection setup type via the `npm:change` script command
- [x] When user is still in local mode: User has been informed that they can only use or access the `dev:atlas` script command when they have switched to ATLAS connection setup type via the `npm:change` script command
- [x] I certify that I ran my checklist

Ping @code-collabo/node-mongo-cli
