### PR TITLE
Fix: Windows OS error for "cleanup" script command

### DIFF
--- a/dev/developer.js
+++ b/dev/developer.js
@@ -6,8 +6,18 @@ const { chdir } = process;
 
 // Dynamically get current the name of this file you are in, and its parent folder
 const developerJsFileName = basename(__filename/*, extname(__filename)*/);
-const cleanupFolderPath = dirname(new URL(import.meta.url).pathname);
 
+const currentFileUrl = import.meta.url;
+
+let newUrl;
+if (process.platform === "darwin" || process.platform === "linux") {
+  newUrl = new URL(currentFileUrl).pathname;
+} else
+  newUrl = new URL(currentFileUrl).pathname.substring(
+    new URL(currentFileUrl).pathname.indexOf("/") + 1
+  );
+
+  const cleanupFolderPath = dirname(newUrl);
 // Change directory into the dynamically gotten parent folder, then extract folder name from path
 chdir(cleanupFolderPath);
 const cleanupFolderName = basename(resolve());


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes code-collabo/put-repo-name-where-the-issue-is-located-here#putTheIssueNumberHere 

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [ ] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

Replace this text with the testing checklist from the issue this pull request fixes.

Ping @code-collabo/node-mongo-cli
